### PR TITLE
Move AccountScreenPreviews out of AccountScreen

### DIFF
--- a/swiftui-router/Screens/Account/AccountScreen.swift
+++ b/swiftui-router/Screens/Account/AccountScreen.swift
@@ -32,10 +32,10 @@ struct AccountScreen: View {
         }
         .padding()
     }
-    
-    struct AccountScreenPreviews: PreviewProvider {
-        static var previews: some View {
-            AccountScreen(router: AccountRouter(services: MockServices()), viewModel: AccountScreenViewModel(services: MockServices()))
-        }
+}
+
+struct AccountScreenPreviews: PreviewProvider {
+    static var previews: some View {
+        AccountScreen(router: AccountRouter(services: MockServices()), viewModel: AccountScreenViewModel(services: MockServices()))
     }
 }


### PR DESCRIPTION
AccountScreenPreviews was inside of the Accountscreen struct. This somehow resulted in two preview views in Xcode.
Note - after making the fix, needed to delete Derived data and restart Xcode.